### PR TITLE
Update object services to set a `$has_more` flag if a call to `*Servi…

### DIFF
--- a/lib/AssociatedContactsService.php
+++ b/lib/AssociatedContactsService.php
@@ -34,14 +34,28 @@ class AssociatedContactsService
    * Returns all deal associated contacts
    *
    * @param integer $deal_id Unique identifier of a Deal
-   * @param array $options Search options
+   * @param array $params Search parameters
+   * @param bool $has_more Flag set to true|false depending if there are more pages of data to fetch
    * 
    * @return array The list of AssociatedContacts for the first page, unless otherwise specified.
    */
-  public function all($deal_id, $options = [])
+  public function all($deal_id, $params = [], &$has_more = null)
   {
-    list($code, $associated_contacts) = $this->httpClient->get("/deals/{$deal_id}/associated_contacts", $options);
-    return $associated_contacts;  
+    $options      = [];
+    $needs_unwrap = false;
+    if( count( func_get_args()) > 1 ) { // -- hasMore flag was provided
+      $options      = ['raw' => true];
+      $needs_unwrap = true;
+    }
+
+    list($code, $items) = $this->httpClient->get("/deals/{$deal_id}/associated_contacts", $params, $options);
+
+    if( $needs_unwrap ) { // -- raw response
+      $has_more = isset( $items['meta']['links']['next_page'] );
+      $items    = $items['items'];
+    }
+
+    return $items;
   }
 
   /**

--- a/lib/ContactsService.php
+++ b/lib/ContactsService.php
@@ -33,14 +33,28 @@ class ContactsService
    * 
    * Returns all contacts available to the user according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search parameters
+   * @param bool $has_more Flag set to true|false depending if there are more pages of data to fetch
    * 
    * @return array The list of Contacts for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], &$has_more = null)
   {
-    list($code, $contacts) = $this->httpClient->get("/contacts", $options);
-    return $contacts;  
+    $options      = [];
+    $needs_unwrap = false;
+    if( count( func_get_args()) > 1 ) { // -- hasMore flag was provided
+      $options      = ['raw' => true];
+      $needs_unwrap = true;
+    }
+
+    list($code, $items) = $this->httpClient->get("/contacts", $params, $options);
+
+    if( $needs_unwrap ) { // -- raw response
+      $has_more = isset( $items['meta']['links']['next_page'] );
+      $items    = $items['items'];
+    }
+
+    return $items;  
   }
 
   /**

--- a/lib/DealsService.php
+++ b/lib/DealsService.php
@@ -33,14 +33,28 @@ class DealsService
    * 
    * Returns all deals available to the user according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search parameters
+   * @param bool $has_more Flag set to true|false depending if there are more pages of data to fetch
    * 
    * @return array The list of Deals for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], &$has_more = null)
   {
-    list($code, $deals) = $this->httpClient->get("/deals", $options);
-    return $deals;  
+    $options      = [];
+    $needs_unwrap = false;
+    if( count( func_get_args()) > 1 ) { // -- hasMore flag was provided
+      $options      = ['raw' => true];
+      $needs_unwrap = true;
+    }
+
+    list($code, $items) = $this->httpClient->get("/deals", $params, $options);
+
+    if( $needs_unwrap ) { // -- raw response
+      $has_more = isset( $items['meta']['links']['next_page'] );
+      $items    = $items['items'];
+    }
+
+    return $items;
   }
 
   /**

--- a/lib/LeadsService.php
+++ b/lib/LeadsService.php
@@ -33,14 +33,28 @@ class LeadsService
    * 
    * Returns all leads available to the user, according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search parameters
+   * @param bool $has_more Flag set to true|false depending if there are more pages of data to fetch
    * 
    * @return array The list of Leads for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], &$has_more = null)
   {
-    list($code, $leads) = $this->httpClient->get("/leads", $options);
-    return $leads;  
+    $options      = [];
+    $needs_unwrap = false;
+    if( count( func_get_args()) > 1 ) { // -- has_more flag was provided
+      $options      = ['raw' => true];
+      $needs_unwrap = true;
+    }
+
+    list($code, $items) = $this->httpClient->get("/leads", $params, $options);
+
+    if( $needs_unwrap ) { // -- raw response
+      $has_more = isset( $items['meta']['links']['next_page'] );
+      $items    = $items['items'];
+    }
+
+    return $items;
   }
 
   /**

--- a/lib/LossReasonsService.php
+++ b/lib/LossReasonsService.php
@@ -33,14 +33,28 @@ class LossReasonsService
    * 
    * Returns all deal loss reasons available to the user according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search parameters
+   * @param bool $has_more Flag set to true|false depending if there are more pages of data to fetch
    * 
    * @return array The list of LossReasons for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], &$has_more = null)
   {
-    list($code, $loss_reasons) = $this->httpClient->get("/loss_reasons", $options);
-    return $loss_reasons;  
+    $options      = [];
+    $needs_unwrap = false;
+    if( count( func_get_args()) > 1 ) { // -- has_more flag was provided
+      $options      = ['raw' => true];
+      $needs_unwrap = true;
+    }
+
+    list($code, $items) = $this->httpClient->get("/loss_reasons", $params, $options);
+
+    if( $needs_unwrap ) { // -- raw response
+      $has_more = isset( $items['meta']['links']['next_page'] );
+      $items    = $items['items'];
+    }
+
+    return $items;
   }
 
   /**

--- a/lib/NotesService.php
+++ b/lib/NotesService.php
@@ -33,14 +33,28 @@ class NotesService
    * 
    * Returns all notes available to the user, according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search parameters
+   * @param bool $has_more Flag set to true|false depending if there are more pages of data to fetch
    * 
    * @return array The list of Notes for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], &$has_more = null)
   {
-    list($code, $notes) = $this->httpClient->get("/notes", $options);
-    return $notes;  
+    $options      = [];
+    $needs_unwrap = false;
+    if( count( func_get_args()) > 1 ) { // -- has_more flag was provided
+      $options      = ['raw' => true];
+      $needs_unwrap = true;
+    }
+
+    list($code, $items) = $this->httpClient->get("/notes", $params, $options);
+
+    if( $needs_unwrap ) { // -- raw response
+      $has_more = isset( $items['meta']['links']['next_page'] );
+      $items    = $items['items'];
+    }
+
+    return $items;
   }
 
   /**

--- a/lib/PipelinesService.php
+++ b/lib/PipelinesService.php
@@ -30,13 +30,27 @@ class PipelinesService
    * 
    * Returns all pipelines available to the user, according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search parameters
+   * @param bool $has_more Flag set to true|false depending if there are more pages of data to fetch
    * 
    * @return array The list of Pipelines for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], &$has_more = null)
   {
-    list($code, $pipelines) = $this->httpClient->get("/pipelines", $options);
-    return $pipelines;  
+    $options      = [];
+    $needs_unwrap = false;
+    if( count( func_get_args()) > 1 ) { // -- has_more flag was provided
+      $options      = ['raw' => true];
+      $needs_unwrap = true;
+    }
+
+    list($code, $items) = $this->httpClient->get("/pipelines", $params, $options);
+
+    if( $needs_unwrap ) { // -- raw response
+      $has_more = isset( $items['meta']['links']['next_page'] );
+      $items    = $items['items'];
+    }
+
+    return $items;
   }
 }

--- a/lib/SourcesService.php
+++ b/lib/SourcesService.php
@@ -33,14 +33,28 @@ class SourcesService
    * 
    * Returns all deal sources available to the user according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search parameters
+   * @param bool $has_more Flag set to true|false depending if there are more pages of data to fetch
    * 
    * @return array The list of Sources for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], &$has_more = null)
   {
-    list($code, $sources) = $this->httpClient->get("/sources", $options);
-    return $sources;  
+    $options      = [];
+    $needs_unwrap = false;
+    if( count( func_get_args()) > 1 ) { // -- has_more flag was provided
+      $options      = ['raw' => true];
+      $needs_unwrap = true;
+    }
+
+    list($code, $items) = $this->httpClient->get("/sources", $params, $options);
+
+    if( $needs_unwrap ) { // -- raw response
+      $has_more = isset( $items['meta']['links']['next_page'] );
+      $items    = $items['items'];
+    }
+
+    return $items;
   }
 
   /**

--- a/lib/StagesService.php
+++ b/lib/StagesService.php
@@ -30,13 +30,27 @@ class StagesService
    * 
    * Returns all stages available to the user, according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search parameters
+   * @param bool $has_more Flag set to true|false depending if there are more pages of data to fetch
    * 
    * @return array The list of Stages for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], &$has_more = null)
   {
-    list($code, $stages) = $this->httpClient->get("/stages", $options);
-    return $stages;  
+    $options      = [];
+    $needs_unwrap = false;
+    if( count( func_get_args()) > 1 ) { // -- has_more flag was provided
+      $options      = ['raw' => true];
+      $needs_unwrap = true;
+    }
+
+    list($code, $items) = $this->httpClient->get("/stages", $params, $options);
+
+    if( $needs_unwrap ) { // -- raw response
+      $has_more = isset( $items['meta']['links']['next_page'] );
+      $items    = $items['items'];
+    }
+
+    return $items;
   }
 }

--- a/lib/TagsService.php
+++ b/lib/TagsService.php
@@ -33,14 +33,28 @@ class TagsService
    * 
    * Returns all tags available to the user, according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $paramss Search parameters
+   * @param bool $has_more Flag set to true|false depending if there are more pages of data to fetch
    * 
    * @return array The list of Tags for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], &$has_more = null)
   {
-    list($code, $tags) = $this->httpClient->get("/tags", $options);
-    return $tags;  
+    $options      = [];
+    $needs_unwrap = false;
+    if( count( func_get_args()) > 1 ) { // -- has_more flag was provided
+      $options      = ['raw' => true];
+      $needs_unwrap = true;
+    }
+
+    list($code, $items) = $this->httpClient->get("/tags", $params, $options);
+
+    if( $needs_unwrap ) { // -- raw response
+      $has_more = isset( $items['meta']['links']['next_page'] );
+      $items    = $items['items'];
+    }
+
+    return $items;
   }
 
   /**

--- a/lib/TasksService.php
+++ b/lib/TasksService.php
@@ -35,14 +35,28 @@ class TasksService
    * If you ask for tasks without any parameter provided Base API will return you both **floating** and **related** tasks
    * Although you can narrow the search set to either of them via query parameters
    *
-   * @param array $options Search options
+   * @param array $params Search parameters
+   * @param bool $has_more Flag set to true|false depending if there are more pages of data to fetch
    * 
    * @return array The list of Tasks for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], &$has_more = null)
   {
-    list($code, $tasks) = $this->httpClient->get("/tasks", $options);
-    return $tasks;  
+    $options      = [];
+    $needs_unwrap = false;
+    if( count( func_get_args()) > 1 ) { // -- has_more flag was provided
+      $options      = ['raw' => true];
+      $needs_unwrap = true;
+    }
+
+    list($code, $items) = $this->httpClient->get("/tasks", $params, $options);
+
+    if( $needs_unwrap ) { // -- raw response
+      $has_more = isset( $items['meta']['links']['next_page'] );
+      $items    = $items['items'];
+    }
+
+    return $items;
   }
 
   /**

--- a/lib/UsersService.php
+++ b/lib/UsersService.php
@@ -30,14 +30,28 @@ class UsersService
    * 
    * Returns all users, according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search parameters
+   * @param bool $has_more Flag set to true|false depending if there are more pages of data to fetch
    * 
    * @return array The list of Users for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], &$has_more = null)
   {
-    list($code, $users) = $this->httpClient->get("/users", $options);
-    return $users;  
+    $options      = [];
+    $needs_unwrap = false;
+    if( count( func_get_args()) > 1 ) { // -- has_more flag was provided
+      $options      = ['raw' => true];
+      $needs_unwrap = true;
+    }
+
+    list($code, $items) = $this->httpClient->get("/users", $params, $options);
+
+    if( $needs_unwrap ) { // -- raw response
+      $has_more = isset( $items['meta']['links']['next_page'] );
+      $items    = $items['items'];
+    }
+
+    return $items;
   }
 
   /**

--- a/tests/AccountsServiceTest.php
+++ b/tests/AccountsServiceTest.php
@@ -16,7 +16,6 @@ class AccountsServiceTest extends TestCase
   public function testSelf()
   {
     $resource = self::$client->accounts->self();
-    $this->assertInternalType('array', $resource);
- 
+    $this->assertInternalType('array', $resource); 
   }
 }  

--- a/tests/AssociatedContactsServiceTest.php
+++ b/tests/AssociatedContactsServiceTest.php
@@ -25,22 +25,21 @@ class AssociatedContactsServiceTest extends TestCase
 
   public function testAll()
   {
-    $associatedContacts = self::$client->associatedContacts->all(self::$associatedContact['deal_id'], ['page' => 1]);
+    $has_more           = null;
+    $associatedContacts = self::$client->associatedContacts->all(self::$associatedContact['deal_id'], ['page' => 1], $has_more);
     $this->assertInternalType('array', $associatedContacts);
- 
+    $this->assertNotNull( $has_more, '$has_more flag not modified' );
   }
 
   public function testCreate()
   {
     $this->assertInternalType('array', self::$associatedContact);
-    $this->assertGreaterThanOrEqual(1, count(self::$associatedContact));
- 
+    $this->assertGreaterThanOrEqual(1, count(self::$associatedContact)); 
   }
 
   public function testDestroy()
   {
     $newAssociatedContact = self::createAssociatedContact();
-    $this->assertTrue(self::$client->associatedContacts->destroy($newAssociatedContact['deal_id'], $newAssociatedContact['contact_id']));
- 
+    $this->assertTrue(self::$client->associatedContacts->destroy($newAssociatedContact['deal_id'], $newAssociatedContact['contact_id'])); 
   }
 }  

--- a/tests/ContactsServiceTest.php
+++ b/tests/ContactsServiceTest.php
@@ -35,38 +35,35 @@ class ContactsServiceTest extends TestCase
 
   public function testAll()
   {
-    $contacts = self::$client->contacts->all(['page' => 1]);
+    $has_more = null;
+    $contacts = self::$client->contacts->all(['page' => 1], $has_more);
     $this->assertInternalType('array', $contacts);
- 
+    $this->assertNotNull( $has_more, '$has_more flag not modified' ); 
   }
 
   public function testCreate()
   {
     $this->assertInternalType('array', self::$contact);
-    $this->assertGreaterThanOrEqual(1, count(self::$contact));
- 
+    $this->assertGreaterThanOrEqual(1, count(self::$contact)); 
   }
 
   public function testGet()
   {
     $foundContact = self::$client->contacts->get(self::$contact['id']);
     $this->assertInternalType('array', $foundContact);
-    $this->assertEquals($foundContact['id'], self::$contact['id']);
- 
+    $this->assertEquals($foundContact['id'], self::$contact['id']); 
   }
 
   public function testUpdate()
   {
     $updatedContact = self::$client->contacts->update(self::$contact['id'], self::$contact);
     $this->assertInternalType('array', $updatedContact);
-    $this->assertEquals($updatedContact['id'], self::$contact['id']);
- 
+    $this->assertEquals($updatedContact['id'], self::$contact['id']); 
   }
 
   public function testDestroy()
   {
     $newContact = self::createContact();
-    $this->assertTrue(self::$client->contacts->destroy($newContact['id']));
- 
+    $this->assertTrue(self::$client->contacts->destroy($newContact['id'])); 
   }
 }  

--- a/tests/DealsServiceTest.php
+++ b/tests/DealsServiceTest.php
@@ -35,38 +35,35 @@ class DealsServiceTest extends TestCase
 
   public function testAll()
   {
-    $deals = self::$client->deals->all(['page' => 1]);
+    $has_more = null;
+    $deals    = self::$client->deals->all(['page' => 1], $has_more);
     $this->assertInternalType('array', $deals);
- 
+    $this->assertNotNull( $has_more, '$has_more flag not modified' );
   }
 
   public function testCreate()
   {
     $this->assertInternalType('array', self::$deal);
-    $this->assertGreaterThanOrEqual(1, count(self::$deal));
- 
+    $this->assertGreaterThanOrEqual(1, count(self::$deal)); 
   }
 
   public function testGet()
   {
     $foundDeal = self::$client->deals->get(self::$deal['id']);
     $this->assertInternalType('array', $foundDeal);
-    $this->assertEquals($foundDeal['id'], self::$deal['id']);
- 
+    $this->assertEquals($foundDeal['id'], self::$deal['id']); 
   }
 
   public function testUpdate()
   {
     $updatedDeal = self::$client->deals->update(self::$deal['id'], self::$deal);
     $this->assertInternalType('array', $updatedDeal);
-    $this->assertEquals($updatedDeal['id'], self::$deal['id']);
- 
+    $this->assertEquals($updatedDeal['id'], self::$deal['id']); 
   }
 
   public function testDestroy()
   {
     $newDeal = self::createDeal();
-    $this->assertTrue(self::$client->deals->destroy($newDeal['id']));
- 
+    $this->assertTrue(self::$client->deals->destroy($newDeal['id'])); 
   }
 }  

--- a/tests/LeadsServiceTest.php
+++ b/tests/LeadsServiceTest.php
@@ -35,38 +35,35 @@ class LeadsServiceTest extends TestCase
 
   public function testAll()
   {
-    $leads = self::$client->leads->all(['page' => 1]);
+    $has_more = null;
+    $leads    = self::$client->leads->all(['page' => 1], $has_more);
     $this->assertInternalType('array', $leads);
- 
+    $this->assertNotNull( $has_more, '$has_more flag not modified' ); 
   }
 
   public function testCreate()
   {
     $this->assertInternalType('array', self::$lead);
-    $this->assertGreaterThanOrEqual(1, count(self::$lead));
- 
+    $this->assertGreaterThanOrEqual(1, count(self::$lead)); 
   }
 
   public function testGet()
   {
     $foundLead = self::$client->leads->get(self::$lead['id']);
     $this->assertInternalType('array', $foundLead);
-    $this->assertEquals($foundLead['id'], self::$lead['id']);
- 
+    $this->assertEquals($foundLead['id'], self::$lead['id']); 
   }
 
   public function testUpdate()
   {
     $updatedLead = self::$client->leads->update(self::$lead['id'], self::$lead);
     $this->assertInternalType('array', $updatedLead);
-    $this->assertEquals($updatedLead['id'], self::$lead['id']);
- 
+    $this->assertEquals($updatedLead['id'], self::$lead['id']); 
   }
 
   public function testDestroy()
   {
     $newLead = self::createLead();
-    $this->assertTrue(self::$client->leads->destroy($newLead['id']));
- 
+    $this->assertTrue(self::$client->leads->destroy($newLead['id'])); 
   }
 }  

--- a/tests/LossReasonsServiceTest.php
+++ b/tests/LossReasonsServiceTest.php
@@ -35,38 +35,35 @@ class LossReasonsServiceTest extends TestCase
 
   public function testAll()
   {
-    $lossReasons = self::$client->lossReasons->all(['page' => 1]);
+    $has_more    = null;
+    $lossReasons = self::$client->lossReasons->all(['page' => 1], $has_more);
     $this->assertInternalType('array', $lossReasons);
- 
+    $this->assertNotNull( $has_more, '$has_more flag not modified' );
   }
 
   public function testCreate()
   {
     $this->assertInternalType('array', self::$lossReason);
-    $this->assertGreaterThanOrEqual(1, count(self::$lossReason));
- 
+    $this->assertGreaterThanOrEqual(1, count(self::$lossReason)); 
   }
 
   public function testGet()
   {
     $foundLossReason = self::$client->lossReasons->get(self::$lossReason['id']);
     $this->assertInternalType('array', $foundLossReason);
-    $this->assertEquals($foundLossReason['id'], self::$lossReason['id']);
- 
+    $this->assertEquals($foundLossReason['id'], self::$lossReason['id']); 
   }
 
   public function testUpdate()
   {
     $updatedLossReason = self::$client->lossReasons->update(self::$lossReason['id'], self::$lossReason);
     $this->assertInternalType('array', $updatedLossReason);
-    $this->assertEquals($updatedLossReason['id'], self::$lossReason['id']);
- 
+    $this->assertEquals($updatedLossReason['id'], self::$lossReason['id']); 
   }
 
   public function testDestroy()
   {
     $newLossReason = self::createLossReason();
-    $this->assertTrue(self::$client->lossReasons->destroy($newLossReason['id']));
- 
+    $this->assertTrue(self::$client->lossReasons->destroy($newLossReason['id'])); 
   }
 }  

--- a/tests/NotesServiceTest.php
+++ b/tests/NotesServiceTest.php
@@ -35,38 +35,35 @@ class NotesServiceTest extends TestCase
 
   public function testAll()
   {
-    $notes = self::$client->notes->all(['page' => 1]);
+    $has_more = null;
+    $notes    = self::$client->notes->all(['page' => 1], $has_more);
     $this->assertInternalType('array', $notes);
- 
+    $this->assertNotNull( $has_more, '$has_more flag not modified' );
   }
 
   public function testCreate()
   {
     $this->assertInternalType('array', self::$note);
-    $this->assertGreaterThanOrEqual(1, count(self::$note));
- 
+    $this->assertGreaterThanOrEqual(1, count(self::$note)); 
   }
 
   public function testGet()
   {
     $foundNote = self::$client->notes->get(self::$note['id']);
     $this->assertInternalType('array', $foundNote);
-    $this->assertEquals($foundNote['id'], self::$note['id']);
- 
+    $this->assertEquals($foundNote['id'], self::$note['id']); 
   }
 
   public function testUpdate()
   {
     $updatedNote = self::$client->notes->update(self::$note['id'], self::$note);
     $this->assertInternalType('array', $updatedNote);
-    $this->assertEquals($updatedNote['id'], self::$note['id']);
- 
+    $this->assertEquals($updatedNote['id'], self::$note['id']); 
   }
 
   public function testDestroy()
   {
     $newNote = self::createNote();
-    $this->assertTrue(self::$client->notes->destroy($newNote['id']));
- 
+    $this->assertTrue(self::$client->notes->destroy($newNote['id'])); 
   }
 }  

--- a/tests/PipelinesServiceTest.php
+++ b/tests/PipelinesServiceTest.php
@@ -15,8 +15,9 @@ class PipelinesServiceTest extends TestCase
 
   public function testAll()
   {
-    $pipelines = self::$client->pipelines->all(['page' => 1]);
+    $has_more  = null;
+    $pipelines = self::$client->pipelines->all(['page' => 1], $has_more);
     $this->assertInternalType('array', $pipelines);
- 
+    $this->assertNotNull( $has_more, '$has_more flag not modified' );
   }
 }  

--- a/tests/SourcesServiceTest.php
+++ b/tests/SourcesServiceTest.php
@@ -35,38 +35,35 @@ class SourcesServiceTest extends TestCase
 
   public function testAll()
   {
-    $sources = self::$client->sources->all(['page' => 1]);
+    $has_more = null;
+    $sources  = self::$client->sources->all(['page' => 1], $has_more);
     $this->assertInternalType('array', $sources);
- 
+    $this->assertNotNull( $has_more, '$has_more flag not modified' );
   }
 
   public function testCreate()
   {
     $this->assertInternalType('array', self::$source);
-    $this->assertGreaterThanOrEqual(1, count(self::$source));
- 
+    $this->assertGreaterThanOrEqual(1, count(self::$source)); 
   }
 
   public function testGet()
   {
     $foundSource = self::$client->sources->get(self::$source['id']);
     $this->assertInternalType('array', $foundSource);
-    $this->assertEquals($foundSource['id'], self::$source['id']);
- 
+    $this->assertEquals($foundSource['id'], self::$source['id']); 
   }
 
   public function testUpdate()
   {
     $updatedSource = self::$client->sources->update(self::$source['id'], self::$source);
     $this->assertInternalType('array', $updatedSource);
-    $this->assertEquals($updatedSource['id'], self::$source['id']);
- 
+    $this->assertEquals($updatedSource['id'], self::$source['id']); 
   }
 
   public function testDestroy()
   {
     $newSource = self::createSource();
-    $this->assertTrue(self::$client->sources->destroy($newSource['id']));
- 
+    $this->assertTrue(self::$client->sources->destroy($newSource['id'])); 
   }
 }  

--- a/tests/StagesServiceTest.php
+++ b/tests/StagesServiceTest.php
@@ -15,8 +15,9 @@ class StagesServiceTest extends TestCase
 
   public function testAll()
   {
-    $stages = self::$client->stages->all(['page' => 1]);
+    $has_more = null;
+    $stages   = self::$client->stages->all(['page' => 1], $has_more);
     $this->assertInternalType('array', $stages);
- 
+    $this->assertNotNull( $has_more, '$has_more flag not modified' );
   }
 }  

--- a/tests/TagsServiceTest.php
+++ b/tests/TagsServiceTest.php
@@ -35,38 +35,35 @@ class TagsServiceTest extends TestCase
 
   public function testAll()
   {
-    $tags = self::$client->tags->all(['page' => 1]);
-    $this->assertInternalType('array', $tags);
- 
+    $has_more = null;
+    $tags     = self::$client->tags->all(['page' => 1], $has_more);
+    $this->assertInternalType('array', $tags); 
+    $this->assertNotNull( $has_more, '$has_more flag not modified' );
   }
 
   public function testCreate()
   {
     $this->assertInternalType('array', self::$tag);
-    $this->assertGreaterThanOrEqual(1, count(self::$tag));
- 
+    $this->assertGreaterThanOrEqual(1, count(self::$tag)); 
   }
 
   public function testGet()
   {
     $foundTag = self::$client->tags->get(self::$tag['id']);
     $this->assertInternalType('array', $foundTag);
-    $this->assertEquals($foundTag['id'], self::$tag['id']);
- 
+    $this->assertEquals($foundTag['id'], self::$tag['id']); 
   }
 
   public function testUpdate()
   {
     $updatedTag = self::$client->tags->update(self::$tag['id'], self::$tag);
     $this->assertInternalType('array', $updatedTag);
-    $this->assertEquals($updatedTag['id'], self::$tag['id']);
- 
+    $this->assertEquals($updatedTag['id'], self::$tag['id']); 
   }
 
   public function testDestroy()
   {
     $newTag = self::createTag();
-    $this->assertTrue(self::$client->tags->destroy($newTag['id']));
- 
+    $this->assertTrue(self::$client->tags->destroy($newTag['id'])); 
   }
 }  

--- a/tests/TasksServiceTest.php
+++ b/tests/TasksServiceTest.php
@@ -35,38 +35,35 @@ class TasksServiceTest extends TestCase
 
   public function testAll()
   {
-    $tasks = self::$client->tasks->all(['page' => 1]);
+    $has_more = null;
+    $tasks    = self::$client->tasks->all(['page' => 1], $has_more);
     $this->assertInternalType('array', $tasks);
- 
+    $this->assertNotNull( $has_more, '$has_more flag not modified' );
   }
 
   public function testCreate()
   {
     $this->assertInternalType('array', self::$task);
-    $this->assertGreaterThanOrEqual(1, count(self::$task));
- 
+    $this->assertGreaterThanOrEqual(1, count(self::$task)); 
   }
 
   public function testGet()
   {
     $foundTask = self::$client->tasks->get(self::$task['id']);
     $this->assertInternalType('array', $foundTask);
-    $this->assertEquals($foundTask['id'], self::$task['id']);
- 
+    $this->assertEquals($foundTask['id'], self::$task['id']); 
   }
 
   public function testUpdate()
   {
     $updatedTask = self::$client->tasks->update(self::$task['id'], self::$task);
     $this->assertInternalType('array', $updatedTask);
-    $this->assertEquals($updatedTask['id'], self::$task['id']);
- 
+    $this->assertEquals($updatedTask['id'], self::$task['id']); 
   }
 
   public function testDestroy()
   {
     $newTask = self::createTask();
-    $this->assertTrue(self::$client->tasks->destroy($newTask['id']));
- 
+    $this->assertTrue(self::$client->tasks->destroy($newTask['id'])); 
   }
 }  

--- a/tests/UsersServiceTest.php
+++ b/tests/UsersServiceTest.php
@@ -25,23 +25,22 @@ class UsersServiceTest extends TestCase
 
   public function testAll()
   {
-    $users = self::$client->users->all(['page' => 1]);
+    $has_more = null;
+    $users    = self::$client->users->all(['page' => 1], $has_more);
     $this->assertInternalType('array', $users);
- 
+    $this->assertNotNull( $has_more, '$has_more flag not modified' ); 
   }
 
   public function testGet()
   {
     $foundUser = self::$client->users->get(self::$user['id']);
     $this->assertInternalType('array', $foundUser);
-    $this->assertEquals($foundUser['id'], self::$user['id']);
- 
+    $this->assertEquals($foundUser['id'], self::$user['id']); 
   }
 
   public function testSelf()
   {
     $resource = self::$client->users->self();
-    $this->assertInternalType('array', $resource);
- 
+    $this->assertInternalType('array', $resource); 
   }
 }  


### PR DESCRIPTION
This allows the user to know if there are more pages to be fetched when using `->all()`
#### Example

``` php
// by default searches will return 25 items per page
// if there are more than that, another request needs to be made to fetch the next page
// before this pull request, the only way to do that was to make another request until 0 items were returned
// this means you would always be hitting the API at least one more time that really needed
// this allows you to know if there are more pages or not ahead of time

$page     = 1; // -- starting point
$items    = []; // -- total collection of returned items
$has_more = true; // -- initial state to enter the while loop

while( $has_more ) {
    $search_params['page'] = $page;
    $page_items = $client->deals->all( $search_params, $has_more );
    $items      = array_merge( $items, $page_items );
    $page++;
}

var_dump( count( $items )); // -- will (potentially, if enough records exist) show more than the `per_page` limit enforced by the API
```
