### PR TITLE
Checking so errors in response is set

### DIFF
--- a/lib/Errors/BaseError.php
+++ b/lib/Errors/BaseError.php
@@ -10,10 +10,15 @@ class BaseError extends Exception
   public function __construct($httpStatusCode, $response)
   {
     $this->httpStatusCode = $httpStatusCode;
-    $this->errors = array_map(function($data){ return $data['error'];  }, $response['errors']);
+
+    if (isset($response['errors'])) {
+      $this->errors = array_map(function($data){ return $data['error'];  }, $response['errors']);
+    } else {
+      $this->errors = [];
+    }
 
     $this->meta = $response['meta'];
-  
+
     $extractError = function($error) {
       return "resource=" . @$error['resource'] . " field=" . @$error['field'] . " code=" . $error['code'] . " message=" . $error['message'];
     };


### PR DESCRIPTION
Errors in response can be null. This is setting $this->errors to an empty array if that is the case.